### PR TITLE
Adding a trailing newline to service template

### DIFF
--- a/templates/ustreamer.systemd.j2
+++ b/templates/ustreamer.systemd.j2
@@ -38,8 +38,9 @@ ExecStart={{ ustreamer_dir }}/ustreamer \
   --persistent \
 {% endif %}
 {% if ustreamer_use_dv_timings %}
-  --dv-timings
+  --dv-timings \
 {% endif %}
+
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Otherwise, the command could end in a backslash (line continuation) with no subsequent line.