### PR TITLE
Adjust package collection, fix non-Raspbian ARM

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: collect Debian-specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg62-turbo-dev']"
-  when: ansible_distribution == 'Debian'
+  when: ansible_distribution == 'Debian' and ansible_lsb.id != 'Raspbian'
 
 - name: collect Ubuntu-specific required apt packages
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: collect Raspberry Pi OS specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg8-dev']"
-  when: ansible_architecture.startswith("arm")
+  when: ansible_lsb.id == 'Raspbian'
 
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:
@@ -65,12 +65,12 @@
 - name: collect Debian-specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg62-turbo-dev']"
-  when: ansible_distribution == 'Debian' and not ansible_architecture.startswith("arm")
+  when: ansible_distribution == 'Debian'
 
 - name: collect Ubuntu-specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['gcc', 'libjpeg8', 'libjpeg-dev', 'libjpeg-turbo8', 'libuuid1', 'libbsd0', 'make']"
-  when: ansible_distribution == 'Ubuntu' and not ansible_architecture.startswith("arm")
+  when: ansible_distribution == 'Ubuntu'
 
 - name: install uStreamer pre-requisite packages
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,9 +39,13 @@
   import_tasks: remove_tc358743.yml
   when: ustreamer_capture_device != 'tc358743'
 
+- name: save whether boot config file exists
+  set_fact:
+    ustreamer_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
+
 - name: enable OpenMax IL acceleration on Pi OS
   set_fact:
-    ustreamer_enable_omx: "{{ ansible_architecture.startswith('arm') and ustreamer_encoder != None and ustreamer_encoder.lower() == 'omx' }}"
+    ustreamer_enable_omx: "{{ ustreamer_is_os_raspbian and ustreamer_encoder != None and ustreamer_encoder.lower() == 'omx' }}"
 
 - name: collect universal required apt packages
   set_fact:
@@ -55,7 +59,7 @@
 - name: collect Raspberry Pi OS specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg8-dev']"
-  when: ansible_lsb.id == 'Raspbian'
+  when: ustreamer_is_os_raspbian
 
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:
@@ -65,7 +69,7 @@
 - name: collect Debian-specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg62-turbo-dev']"
-  when: ansible_distribution == 'Debian' and ansible_lsb.id != 'Raspbian'
+  when: ansible_distribution == 'Debian' and not ustreamer_is_os_raspbian
 
 - name: collect Ubuntu-specific required apt packages
   set_fact:


### PR DESCRIPTION
Use `ansible_lsb.id` to detect Raspbian vs naive check of
`ansible_architecture.startswith("arm")`. Remove negative of the same
check from Debian and Ubuntu.

Closes https://github.com/mtlynch/ansible-role-ustreamer/issues/34

Output after changes, on Tritium H3 running Armbian armhf:

```
TASK [mtlynch.ustreamer : collect Raspberry Pi OS specific required apt packages] *********************
skipping: [localhost]

TASK [mtlynch.ustreamer : install libraspberrypi-dev if we're using OpenMax IL acceleration] **********
skipping: [localhost]

TASK [mtlynch.ustreamer : collect Debian-specific required apt packages] ******************************
ok: [localhost]

TASK [mtlynch.ustreamer : collect Ubuntu-specific required apt packages] ******************************
skipping: [localhost]
```