### PR TITLE
Remove obsolete `systemd-config` tag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,6 @@
 # need to install the Janus Debian package beforehand, because it provides
 # C-headers.
 - name: determine whether to install Janus
-  # When applying video settings changes via the `update-video-settings`
-  # privileged script, we run this Ansible role with the `--tag systemd-config`
-  # option. That triggers the `restart Janus` handler down the line, which
-  # relies on the `ustreamer_install_janus` variable being set.
-  tags:
-    - systemd-config
   set_fact:
     ustreamer_install_janus: "{{ ustreamer_h264_sink != None }}"
 
@@ -218,8 +212,6 @@
     - reload systemd config
     - restart uStreamer
     - restart Janus
-  tags:
-    - systemd-config
 
 - name: enable systemd uStreamer service file
   systemd:


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-ustreamer/issues/90.

The [former `update-video-settings` privileged script](https://github.com/tiny-pilot/tinypilot/pull/1252/files#diff-e2338529a436ccc50905f1b522d19b4bab7db189a3988b43d7069ca97a9d47afL77) relied on the `systemd-config` tag to run a fraction of the Ansible role for applying video settings changes. That privileged script is gone now, so we don’t have any need for the `systemd-config` tag any longer.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/95"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>