### PR TITLE
Remove detection/auto-removal of legacy Janus package

### DIFF
--- a/tasks/install_janus.yml
+++ b/tasks/install_janus.yml
@@ -1,20 +1,4 @@
 ---
-- name: check if legacy Janus package is installed
-  shell: dpkg-query --show --showformat='${Maintainer}' janus | grep TinyPilot
-  register: ustreamer_is_legacy_janus_installed
-  ignore_errors: yes
-  changed_when: false
-
-- name: determine if legacy Janus package is installed
-  set_fact:
-    ustreamer_is_legacy_janus_installed: "{{ ustreamer_is_legacy_janus_installed.stdout != '' }}"
-
-- name: uninstall legacy Janus package
-  apt:
-    name: janus
-    state: absent
-  when: ustreamer_is_legacy_janus_installed
-
 - name: install apt_key dependency
   apt:
     name: gnupg


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/104.

TinyPilot Pro’s 2.5.4 release was a checkpoint version, so apart from (hopefully) few Community users, the check and auto-removal of the legacy Janus package isn’t needed any longer.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/106"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>