### PR TITLE
Remove workaround for legacy systemd versions

### DIFF
--- a/tasks/provision_tc358743.yml
+++ b/tasks/provision_tc358743.yml
@@ -46,14 +46,6 @@
     group: "{{ ustreamer_group }}"
     mode: '0644'
 
-- name: get version of systemd
-  shell: systemctl --version | head -n 1 | grep --only-matching --perl-regexp '(?<=systemd )[0-9]+'
-  register: ustreamer_systemd_version_result
-
-- name: save systemd version
-  set_fact:
-    ustreamer_systemd_version: "{{ ustreamer_systemd_version_result.stdout }}"
-
 - name: install TC358743 initializer service
   template:
     src: load-tc358743-edid.systemd.j2

--- a/templates/load-tc358743-edid.systemd.j2
+++ b/templates/load-tc358743-edid.systemd.j2
@@ -6,13 +6,7 @@ StartLimitIntervalSec=300
 StartLimitBurst=20
 
 [Service]
-{# Versions of systemd before 244 didn't support Restart for oneshot services
-   https://github.com/systemd/systemd/pull/13754 #}
-{% if (ustreamer_systemd_version | int) >= 244 %}
 Type=oneshot
-{% else %}
-Type=simple
-{% endif %}
 User=root
 ExecStart=v4l2-ctl \
   --set-edid=file={{ ustreamer_edids_dir }}/tc358743-edid.hex \


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/99 (which was re-opened). In [a previous PR, in which we abandoned Buster-specific compatibility code](https://github.com/tiny-pilot/ansible-role-ustreamer/pull/105), we forgot to remove a workaround that was needed for the systemd version that Buster shipped with.

In versions up until v244, systemd [didn’t support the `on-failure` restart method for “oneshot” type units](https://github.com/systemd/systemd/pull/13754). Therefore, we had to use a “simple” type unit, because [Debian 10 (Buster) shipped with systemd v241](https://packages.debian.org/buster/systemd). However, [Debian 11 (Bullseye) ships with systemd v247](https://packages.debian.org/bullseye/systemd), so we can abandon this workaround now.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/107"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>