### PR TITLE
Optionally install uStreamer from Debian package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+# Specifies the filesystem path or URL of a Debian package that installs
+# uStreamer.
+ustreamer_debian_package_path: null
+
 ustreamer_repo: https://github.com/pikvm/ustreamer.git
 ustreamer_repo_version: master
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,4 +25,3 @@
         ustreamer_h264_sink: tinypilot::ustreamer::h264
         ustreamer_h264_sink_mode: 777
         ustreamer_h264_sink_rm: yes
-        ustreamer_debian_package_path: https://output.circle-artifacts.com/output/job/a3d6246b-bad5-44ae-a972-0a20c7cf1442/artifacts/0/build/linux_amd64/ustreamer_5.38-20230517221849_amd64.deb

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,3 +25,4 @@
         ustreamer_h264_sink: tinypilot::ustreamer::h264
         ustreamer_h264_sink_mode: 777
         ustreamer_h264_sink_rm: yes
+        ustreamer_debian_package_path: https://output.circle-artifacts.com/output/job/a3d6246b-bad5-44ae-a972-0a20c7cf1442/artifacts/0/build/linux_amd64/ustreamer_5.38-20230517221849_amd64.deb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,6 +113,11 @@
     name: "{{ ustreamer_packages }}"
     state: present
 
+- name: install uStreamer Debian package
+  apt:
+    deb: "{{ ustreamer_debian_package_path }}"
+  when: ustreamer_debian_package_path != None
+
 - name: create uStreamer folder
   file:
     path: "{{ ustreamer_dir }}"
@@ -125,6 +130,7 @@
     # to set the correct directory ownership that allows git to sync.
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
+  when: ustreamer_debian_package_path == None
 
 - name: get uStreamer repo
   # Don't escalate privileges because only the directory owner can use git.
@@ -139,6 +145,7 @@
     # idempotency test on the previous task that allows git to sync.
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
+  when: ustreamer_debian_package_path == None
 
 # We always need to clean and build uStreamer to ensure that the uStreamer
 # service is in sync with its dependencies installed on the device.
@@ -149,6 +156,7 @@
     target: clean
   tags:
     - molecule-idempotence-notest
+  when: ustreamer_debian_package_path == None
 
 - name: build uStreamer
   make:
@@ -159,6 +167,7 @@
     - restart uStreamer
   tags:
     - molecule-idempotence-notest
+  when: ustreamer_debian_package_path == None
 
 - name: fix uStreamer folder permissions
   file:
@@ -212,7 +221,7 @@
     dest: "{{ ustreamer_janus_plugins_dir }}"
   notify:
     - restart Janus
-  when: ustreamer_install_janus
+  when: ustreamer_debian_package_path == None and ustreamer_install_janus
 
 - name: install uStreamer launcher
   import_tasks: install_launcher.yml


### PR DESCRIPTION
Related https://github.com/tiny-pilot/ansible-role-ustreamer/issues/100

This PR only builds uStreamer from source if a uStreamer Debian package is not provided. This will allow TinyPilot to specify a uStreamer Debian package and avoid building uStreamer from source on every install/update.

I've [tested these changes in CI](https://app.circleci.com/pipelines/github/tiny-pilot/ansible-role-ustreamer/371/workflows/f85d89d6-bf24-40e7-868b-692299e6c38e/jobs/962?invite=true#step-104-396) via https://github.com/tiny-pilot/ansible-role-ustreamer/pull/110/commits/179fe044319d505e7bf48c0ac713741f06b3bae4.

I've also tested these changes on device via a [scratch TinyPilot Pro PR](https://github.com/tiny-pilot/tinypilot-pro/pull/908).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/110"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>